### PR TITLE
Adds Build Arg to Package Command

### DIFF
--- a/cmd/skpr/package/command.go
+++ b/cmd/skpr/package/command.go
@@ -44,6 +44,7 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&command.Params.NoPush, "no-push", command.Params.NoPush, "Do not push the image to the registry.")
 	cmd.Flags().BoolVar(&command.PrintManifest, "print-manifest", command.PrintManifest, "Print the manifest to stdout.")
 	cmd.Flags().StringVar(&command.PackageDir, "dir", ".skpr/package", "The location of the package directory.")
+	cmd.Flags().StringSliceVar(&command.BuildArgs, "build-arg", []string{}, "Additional build arguments.")
 	cmd.Flags().BoolVar(&command.Debug, "debug", command.Debug, "Enable debug output.")
 
 	return cmd

--- a/internal/buildpack/builder/builder.go
+++ b/internal/buildpack/builder/builder.go
@@ -56,12 +56,13 @@ type Image struct {
 
 // Params used for building the applications.
 type Params struct {
-	Auth     docker.AuthConfiguration
-	Writer   io.Writer
-	Context  string
-	Registry string
-	NoPush   bool
-	Version  string
+	Auth      docker.AuthConfiguration
+	Writer    io.Writer
+	Context   string
+	Registry  string
+	NoPush    bool
+	Version   string
+	BuildArgs map[string]string
 }
 
 // Dockerfiles the docker build files.
@@ -98,6 +99,13 @@ func (b *Builder) Build(dockerfiles Dockerfiles, params Params) (BuildResponse, 
 			Name:  BuildArgVersion,
 			Value: params.Version,
 		},
+	}
+
+	for k, v := range params.BuildArgs {
+		args = append(args, docker.BuildArg{
+			Name:  k,
+			Value: v,
+		})
 	}
 
 	start := time.Now()

--- a/internal/command/package/command.go
+++ b/internal/command/package/command.go
@@ -24,6 +24,7 @@ import (
 	"github.com/skpr/cli/internal/buildpack/utils/finder"
 	"github.com/skpr/cli/internal/buildpack/utils/notation/utils"
 	"github.com/skpr/cli/internal/client"
+	"github.com/skpr/cli/internal/slice"
 )
 
 // Command to package an application.
@@ -32,6 +33,7 @@ type Command struct {
 	PackageDir    string
 	Params        buildpack.Params
 	PrintManifest bool
+	BuildArgs     []string
 	Debug         bool
 }
 
@@ -65,6 +67,10 @@ func (cmd *Command) Run(ctx context.Context) error {
 		Username: client.Credentials.Username,
 		Password: client.Credentials.Password,
 	}
+
+	// Convert build args from slice to map.
+	//   eg. --build-arg=KEY=VALUE to map[string]string{"KEY": "VALUE"}
+	cmd.Params.BuildArgs = slice.ToMap(cmd.BuildArgs, "=")
 
 	isECR := ecr.IsRegistry(cmd.Params.Registry)
 

--- a/internal/slice/slice.go
+++ b/internal/slice/slice.go
@@ -1,5 +1,7 @@
 package slice
 
+import "strings"
+
 // Contains a string within a slice.
 func Contains(slice []string, s string) bool {
 	for _, item := range slice {
@@ -66,4 +68,21 @@ func AppendIfMissing(slice []string, i string) []string {
 	}
 
 	return append(slice, i)
+}
+
+// ToMap converts a slice of strings into a map using the provided delimiter.
+func ToMap(slice []string, delimiter string) map[string]string {
+	m := make(map[string]string, len(slice))
+
+	for _, s := range slice {
+		sl := strings.Split(s, delimiter)
+
+		if len(sl) != 2 {
+			continue
+		}
+
+		m[sl[0]] = sl[1]
+	}
+
+	return m
 }


### PR DESCRIPTION
**Overview**

Adds the ability to add build args to the compile stage using packaging.

```$
skpr package 0.0.1 --build-arg=FOO=BAR
```