### PR TITLE
fix(validate): do not print table when there are no findings

### DIFF
--- a/internal/command/validate/command.go
+++ b/internal/command/validate/command.go
@@ -65,7 +65,12 @@ func PrintTable(ctx context.Context, w io.Writer, client *client.Client, proto *
 		Environment: proto,
 	})
 	if err != nil {
-		return false, errors.Wrap(err, err.Error())
+		return false, errors.Wrap(err, "failed to validate environment")
+	}
+
+	// Nothing to report - don't print an empty table.
+	if len(resp.Findings) == 0 {
+		return false, nil
 	}
 
 	header := []string{
@@ -89,14 +94,11 @@ func PrintTable(ctx context.Context, w io.Writer, client *client.Client, proto *
 			row = append(row, color.New(color.FgRed).Sprintf("%s", finding.Type.String()))
 		case pb.EnvironmentValidateFinding_Warning:
 			row = append(row, color.New(color.FgBlue).Sprintf("%s", finding.Type.String()))
+		default:
+			row = append(row, finding.Type.String())
 		}
 
 		rows = append(rows, row)
-	}
-
-	// Nothing to report - don't print an empty table.
-	if len(rows) == 0 {
-		return false, nil
 	}
 
 	err = table.Print(w, header, rows)

--- a/internal/command/validate/command.go
+++ b/internal/command/validate/command.go
@@ -94,6 +94,11 @@ func PrintTable(ctx context.Context, w io.Writer, client *client.Client, proto *
 		rows = append(rows, row)
 	}
 
+	// Nothing to report - don't print an empty table.
+	if len(rows) == 0 {
+		return false, nil
+	}
+
 	err = table.Print(w, header, rows)
 	if err != nil {
 		return false, fmt.Errorf("failed to print table: %w", err)


### PR DESCRIPTION
The `skpr validate` command printed table headers even when there were no validation findings. `PrintTable` now returns early when there are no rows, so a clean environment produces no output. The create and deploy commands are unaffected since they only call `PrintTable` when findings exist.